### PR TITLE
Fixes the install failure if gulp not installed already

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "trailsjs"
   ],
   "dependencies": {
+    "cfenv": "^1.0.3",
     "db-migrate": "^0.10.0-beta.20",
     "db-migrate-pg": "0.1.11",
     "express": "^4.14.0",
@@ -29,7 +30,8 @@
     "grunt-cli": "^1.2.0",
     "grunt-sass": "^1.2.0",
     "grunt-sync": "^0.5.2",
-    "cfenv": "^1.0.3",
+    "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
     "nunjucks": "^2.4.2",
     "trailpack-core": "^1.0.1",
     "trailpack-express": "^1.0.9",


### PR DESCRIPTION
Waterline-sql won't install unless gulp and gulp-babel are available,so
have added these to the package.json - ```npm install``` works as
expected now regardless of whether you have gulp installed globally.